### PR TITLE
Potential fix for code scanning alert no. 5: Missing origin verification in `postMessage` handler

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -215,6 +215,13 @@
 
     // Message handling
     window.addEventListener('message', (event) => {
+        const origin = typeof event.origin === 'string' ? event.origin : '';
+        const isSameOrigin = origin === window.location.origin;
+        const isVsCodeWebviewOrigin = /^vscode-webview:\/\//.test(origin);
+        if (!isSameOrigin && !isVsCodeWebviewOrigin) {
+            return;
+        }
+
         const message = event.data;
         switch (message.type) {
             case 'setData':


### PR DESCRIPTION
Potential fix for [https://github.com/tlcsdm/vscode-json-tree-view/security/code-scanning/5](https://github.com/tlcsdm/vscode-json-tree-view/security/code-scanning/5)

Add an explicit trust check at the top of the `window.addEventListener('message', ...)` callback in `media/main.js` before reading `event.data`.  
Best minimal fix (without changing behavior for legitimate messages): allow only messages from trusted origins (same-origin and VS Code webview origins), and return early for anything else.

Concretely, edit the message handler region around lines 216–232:

1. Read `event.origin` safely.
2. Compute trusted conditions:
   - same-origin: `event.origin === window.location.origin`
   - VS Code webview origin pattern: `vscode-webview://...`
3. If neither is true, ignore the message (`return`).
4. Keep existing switch logic unchanged.

No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
